### PR TITLE
fix: remove limit on search category

### DIFF
--- a/functions/services/utilsService.js
+++ b/functions/services/utilsService.js
@@ -15,7 +15,7 @@ class UtilsService {
   async findSuggestedCategories(term) {
     try {
       const { data } = await this.server
-        .get(`/sites/MLB/domain_discovery/search?limit=5&q=${term}`)
+        .get(`/sites/MLB/domain_discovery/search?q=${term}`)
       return Promise.resolve(data)
     } catch (error) {
       if (error.response) {


### PR DESCRIPTION
Aqui está sendo inserido um limite de 10, sendo que o permitido é até 8. Vi que colocou 5, mas por algum motivo está indo 10, por isso preferi retirar ai, não sei se é a melhor solução, talvez seria ao descobrir de onde vem esse 10. Mas segue as imagens:

![image](https://user-images.githubusercontent.com/35343551/149561555-46b32fd1-0fa0-4b19-9d2c-47bb53fa0ba9.png)

Retirando, mostrou as opções:

![image](https://user-images.githubusercontent.com/35343551/149561655-b44dbfd6-c948-4fd5-b14d-c4ee52651787.png)

Veja o que ache melhor ai
